### PR TITLE
docs: TDD 開発規約を追加

### DIFF
--- a/.codex/skills/exec-plan/SKILL.md
+++ b/.codex/skills/exec-plan/SKILL.md
@@ -51,6 +51,21 @@ ExecPlan draft の前に、次の 5 軸を必ず埋めます。ユーザーが�
 
 質問は最大 3 問ずつに分けます。回答が `特になし` の場合も、該当軸を「制約なし」ではなく「明示制約なし」として記録します。
 
+## commit / PR 運用
+
+commit は `commit` skill を正本にします。ExecPlan の承認 scope に commit / PR 作成が含まれる場合は、`commit` skill を使って小さく論理的な単位で commit します。通常 task で commit / PR 作成が scope に含まれない場合は、`AGENTS.md` に従い user が依頼した時だけ commit します。
+
+commit 粒度は、Pro Git、Google Engineering Practices、Conventional Commits の共通原則に従い、次を基準にします。
+
+- 1 commit は 1 つの論理的に独立した changeset にする。1 issue / 1 acceptance / 1 関心事を目安にする。
+- review しやすく、あとから revert / drop しやすい単位にする。迷ったら大きすぎる commit より小さめを選ぶ。
+- feature / bug fix と大きな refactor、機械的変更、設定変更、生成物更新は原則分ける。小さな局所 cleanup は同じ commit に含めてよい。
+- 挙動変更に対応する test / docs / 型更新は、reviewer がその変更を理解・検証するために必要なら同じ commit に含める。
+- commit ごとに repo が意味的に壊れないようにする。検証が環境要因で止まる場合は ExecPlan と最終報告に未検証範囲を残す。
+- Conventional Commits の type が複数にまたがる場合は、可能な限り複数 commit に分ける。
+
+PR 作成・更新は `pr-writer` skill を正本にします。ExecPlan から PR へ進む場合は `pr-writer` skill を使い、title / body / 既存 PR 判定 / UI preview / issue 記載を委譲します。関連 issue が無い場合も blocker にせず、`issueなし` を明示入力として `pr-writer` に渡して PR 作成を継続します。
+
 ## 実行フロー
 
 1. **scope 判定**: ExecPlan が必要か `AGENTS.md` で判定する。必要なら次へ進む。
@@ -60,13 +75,15 @@ ExecPlan draft の前に、次の 5 軸を必ず埋めます。ユーザーが�
 5. **実装**: `具体手順` に沿って小さく編集する。判断変更は `判断記録` と `Change note:` に残す。
 6. **検証**: 原則 `mise run verify`。環境変数不足で止まる場合は、失敗 command、原因、未検証範囲を ExecPlan と最終報告に残す。
 7. **multi-agent review fix loop**: project-local `review` skill を使い、2 つ以上の独立 reviewer を起動する。未解決 finding は scope 内で修正し、同じ reviewer set で最大 2 cycle 再確認する。成立しない場合は完了扱いにしない。
-8. **commit**: 通常 task では user が commit を依頼した時だけ commit skill を使う。spec-to-PR として承認済みの task では、PR 作成に必要な commit を approved scope 内の自律実行として扱う。
-9. **PR 作成**: user が PR 作成を求めた、または task が spec-to-PR として承認済みなら PR を作る。PR body は ExecPlan の目的、検証、review 結果、未検証範囲から作る。
+8. **commit**: commit / PR 作成が承認 scope に含まれる場合は、`commit` skill を使って論理単位ごとにこまめに commit する。spec-to-PR として承認済みの task では、PR 作成に必要な commit を approved scope 内の自律実行として扱う。
+9. **PR 作成**: user が PR 作成を求めた、または task が spec-to-PR として承認済みなら `pr-writer` skill で PR を作成・更新する。関連 issue が無い場合は `issueなし` を明示して進める。
 10. **CI fix**: PR CI が失敗したらログを読み、差分起因の failure を修正する。環境・secret・外部障害は blocker として報告し、推測で隠さない。
 
 ## spec-to-PR 契約
 
 - PR まで進める task では、ExecPlan の `検証と受け入れ条件` に PR 作成条件と CI 成功条件を書く。
+- PR 作成・更新は `pr-writer` skill を使う。issue が無い task でも PR 作成は止めず、PR body の関連 issue を `なし` として扱う。
+- commit は `commit` skill を使い、PR 作成前に論理的に独立した commit history に整える。必要なら `commit --auto` 相当の自動分割方針を使う。
 - CI fix は同じ ExecPlan の scope 内で扱う。scope を超える修正が必要なら user に確認する。
 - PR 作成後も CI が red のままなら、green まで fix loop を続けるか、具体的な blocker を報告する。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ root の `mise` タスクを正本にします。
 ## 参照先
 
 - 詳細規約、分割基準、レビュー観点: `docs/conventions.md`
+- テスト規約 / TDD 方針: `docs/conventions.md` の Testing / TDD policy
 - ExecPlan schema と更新規則: `PLANS.md`
 - 人間向け説明: `README.md`
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -69,6 +69,33 @@ hidden runtime、pipeline directory、別形式の task artifact は増やしま
 - App Router file の local override を、理由なく全体化しない。
 - Prettier は semicolon と double quote。
 
+## Testing / TDD policy（テスト規約）
+
+この repo の開発は、t-wada の TDD を前提に進めます。ここでの TDD は
+「動作するきれいなコード」を目指し、テストリストから 1 つ選び、Red → Green →
+Refactor を小さく回す進め方を指します。
+
+現時点では test runner、test dependency、test file は未導入です。これらは別タスクで
+明示的に導入するまで追加しません。`mise run verify` は引き続き唯一の hard guard です。
+
+テスト基盤がない間も、TDD の意図は維持します。
+
+- 実装前に、期待する振る舞いを test list または acceptance として明示する。
+- バグ修正では、先に失敗している振る舞いと期待する成功状態を書く。
+- 実装は観測可能な振る舞いを 1 つずつ変え、検証結果を最終報告または ExecPlan に残す。
+- test list / acceptance は、ExecPlan がある場合は ExecPlan に、ない小変更ではユーザー要求または着手前メモに置く。
+- Green 相当とは、明示した test list / acceptance を観測可能に満たした状態を指す。
+- Green 相当の状態を確認してから refactor する。挙動変更と refactor を混ぜない。
+
+テスト基盤を導入した後は、次を守ります。
+
+- user-visible behavior、public API、共有関数の契約、regression を優先してテストする。
+- 実装前に失敗するテストを書き、最小実装で Green にする。
+- Green の間だけ refactor し、test と production code の意図を保ったまま整理する。
+- テスト名は実装詳細ではなく、期待する振る舞いを説明する。
+- brittle snapshot や private implementation detail への過度な依存を primary assertion にしない。
+- 外部 service、時刻、乱数、network に依存するテストは、決定的に観測できる境界を作る。
+
 ## Question policy（確認基準）
 
 必ず確認:

--- a/docs/exec-plans/completed/202604252252_tdd_conventions/exec-plan.md
+++ b/docs/exec-plans/completed/202604252252_tdd_conventions/exec-plan.md
@@ -1,0 +1,137 @@
+この ExecPlan は ../../../../PLANS.md の契約に準拠する。
+
+## 目的と全体像
+
+今後の yona.dev 開発で、テスト導入前から t-wada の TDD を前提にした進め方を共有できるようにする。変更後は `docs/conventions.md` にテスト規約が追加され、`AGENTS.md` からその規約を参照できる。実際の test runner、test file、test dependency、CI pipeline はこのタスクでは追加しない。
+
+Assumption: ユーザーの「t-wada の tdd 開発」は、テストリストを起点に Red-Green-Refactor を小さく回し、Green の間だけリファクタリングする進め方を指す。
+
+## 進捗
+
+- [x] 2026-04-25 22:52+09:00 `AGENTS.md`、`PLANS.md`、`docs/conventions.md`、既存 ExecPlan 配置を確認した。
+- [x] 2026-04-25 22:52+09:00 `docs/conventions.md` に Testing / TDD policy を追加した。
+- [x] 2026-04-25 22:52+09:00 `AGENTS.md` に詳細規約への短い参照を追加した。
+- [x] 2026-04-25 22:56+09:00 変更差分を確認し、文書変更として妥当な検証を記録した。
+- [x] 2026-04-25 22:56+09:00 ExecPlan を `docs/exec-plans/completed/202604252252_tdd_conventions/` に移した。
+- [x] 2026-04-25 23:08+09:00 review fix loop の採用 finding を修正し、検証 evidence を更新した。
+- [x] 2026-04-25 23:09+09:00 同じ reviewer set の cycle 2 再確認で `findings なし` を確認した。
+
+## 気づきと発見
+
+Observation: この repo は Hot 層を `AGENTS.md`、Warm 層を `docs/conventions.md`、Cold 層を ExecPlan に分ける設計になっている。
+Evidence:
+    docs/conventions.md の SSoT / CE 方針に、詳細規約は docs/conventions.md、task artifact は docs/exec-plans/{active,completed}/ と記載されている。
+
+Observation: `mise run verify` は唯一の hard guard であり、別 pipeline や別形式の task artifact は増やさない契約になっている。
+Evidence:
+    AGENTS.md の コマンド section と docs/conventions.md の Verification section に `mise run verify` が hard guard として記載されている。
+
+Observation: 今回の repo 差分は文書と ExecPlan に限定され、test runner、test dependency、test file、CI pipeline は追加していない。
+Evidence:
+    git status --short
+     M AGENTS.md
+     M docs/conventions.md
+    ?? docs/exec-plans/completed/202604252252_tdd_conventions/
+
+Observation: `mise run verify` は lint まで成功し、build は既存の runtime env 不足で止まった。
+Evidence:
+    mise run verify
+    [lint] Finished in 16.65s
+    [build] Error: MICROCMS_API_KEY is not set
+    [build] Error: Failed to collect page data for /blog
+
+Observation: review fix loop では `contract-reviewer` と `ce-reviewer` が P3 finding を出し、採用 finding を修正した。
+Evidence:
+    contract-reviewer: completed 後の ExecPlan が active path を参照している点を指摘。
+    ce-reviewer: test list / acceptance の置き場所、Green 相当の定義、fix loop 後 evidence の古さを指摘。
+    修正後、`docs/conventions.md` に test list / acceptance の置き場所と Green 相当の定義を追記し、ExecPlan の検証 command と evidence を更新した。
+
+Observation: review fix loop cycle 2 は同じ reviewer set で未解決 finding なしになった。
+Evidence:
+    contract-reviewer / 019dc4f5-4932-7972-8013-008fd8498f86: findings なし。
+    ce-reviewer / 019dc4f5-499a-78f1-847d-2766f3253440: findings なし。
+
+## 判断記録
+
+Decision: テスト規約の本文は `docs/conventions.md` に置き、`AGENTS.md` には短い参照だけを追加する。
+Rationale: すべての session で読む Hot 層を肥大化させず、既存の CE 方針に沿って詳細規約を Warm 層へ集約するため。
+Date/Author: 2026-04-25 / Codex
+
+Decision: このタスクでは test runner、test dependency、test file、CI pipeline を追加しない。
+Rationale: ユーザーが「実際のテストはまだ導入しない」と明示しており、依存管理と hard guard の契約を変えないため。
+Date/Author: 2026-04-25 / Codex
+
+Decision: Approval gate 1 はユーザーの明示依頼を承認として扱い、documentation-only の範囲で自律実行する。
+Rationale: scope は `AGENTS.md`、`docs/conventions.md`、本 ExecPlan に限定でき、破壊的変更や secret / server-client boundary への影響がないため。
+Date/Author: 2026-04-25 / Codex
+
+## 依存関係と契約
+
+Dependency: `AGENTS.md`
+Reason: agent が最初に読む Hot 層であり、今後の開発前提への入口になるため。
+Contract: 詳細規約を重複させず、`docs/conventions.md` への参照に留める。
+
+Dependency: `docs/conventions.md`
+Reason: repo 固有の詳細規約の正本であり、テスト規約を置く Warm 層であるため。
+Contract: t-wada TDD の前提、テスト導入前の扱い、将来テスト導入時の原則を明文化する。
+
+Dependency: `PLANS.md`
+Reason: この ExecPlan の schema と更新規則の正本であるため。
+Contract: 必須 section、進捗 timestamp、`Change note:` 末尾規則を守る。
+
+## 具体手順
+
+1. `docs/conventions.md` に Testing / TDD policy section を追加する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        apply_patch
+    Expected outcome:
+        テスト導入前でも従える TDD 規約が文書化される。
+
+2. `AGENTS.md` の参照先 section にテスト規約への短い導線を追加する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        apply_patch
+    Expected outcome:
+        agent が Hot 層から詳細規約を発見できる。
+
+3. 差分を確認し、実テスト導入が含まれていないことを確認する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        git diff -- AGENTS.md docs/conventions.md docs/exec-plans/completed/202604252252_tdd_conventions/exec-plan.md
+    Expected outcome:
+        変更は文書と ExecPlan のみに限定される。
+
+## 検証と受け入れ条件
+
+Input: `git diff --stat` と対象ファイルの diff を確認する。
+Observe: `AGENTS.md`、`docs/conventions.md`、本 ExecPlan 以外の変更がない。test runner、test dependency、test file、CI pipeline が追加されていない。`git diff --stat` は `AGENTS.md` 1 行追加、`docs/conventions.md` 27 行追加を示した。
+Failure signal: `web/package.json`、lockfile、test file、CI 設定、`mise.toml`、実行 pipeline に変更が入っている。
+
+Input: `mise run install` 後に `mise run verify` を実行する。
+Observe: `pnpm install` は完了した。`mise run verify` は lint が成功し、build は `/blog` の page data collection で `MICROCMS_API_KEY is not set` により失敗した。差分起因の失敗は観測されていない。
+Failure signal: verify が差分起因で失敗する、または環境変数不足以外の未説明 failure が残る。
+
+Input: fix loop 後に `git diff --check`、untracked ExecPlan の `git diff --no-index --check /dev/null docs/exec-plans/completed/202604252252_tdd_conventions/exec-plan.md`、`mise run verify` を実行する。
+Observe: `git diff --check` は出力なしで成功した。untracked ExecPlan の `--no-index --check` は whitespace error を出していない。`mise run verify` は lint が成功し、build は同じ `MICROCMS_API_KEY is not set` で失敗した。
+Failure signal: whitespace error、差分起因の lint failure、または `MICROCMS_API_KEY` 以外の未説明 build failure が残る。
+
+## 冪等性と復旧
+
+1. 変更は文書への additive な追記なので、同じ section が重複しないように再実行時は既存見出しを確認する。
+2. 失敗時は `git diff` で対象外 file への変更を確認し、対象 file だけを調整する。
+3. migration、生成物、外部 service 更新はない。
+4. test runner や dependency は追加せず、将来導入時に別 task / ExecPlan として扱う。
+5. temporary file、dev server、生成物は作らない。
+
+## 未完了事項
+
+`mise run verify` の build は `MICROCMS_API_KEY` 未設定により完了していない。lint は成功済み。今回の変更は文書のみで、実テスト導入、依存追加、CI 変更は行っていない。
+
+Change note: 2026-04-25 23:09+09:00 cycle 2 の reviewer verdict を記録した。

--- a/docs/exec-plans/completed/202604252324_exec_plan_skill_pr_commit/exec-plan.md
+++ b/docs/exec-plans/completed/202604252324_exec_plan_skill_pr_commit/exec-plan.md
@@ -1,0 +1,148 @@
+この ExecPlan は ../../../../PLANS.md の契約に準拠する。
+
+## 目的と全体像
+
+`.codex/skills/exec-plan/SKILL.md` に、PR 作成と commit 粒度の運用を明文化する。変更後は、ExecPlan skill から PR 作成へ進む場合に `pr-writer` skill を使い、issue が無い場合でも `issueなし` として自動作成できる。commit は `commit` skill を使い、調査した一般的な commit 粒度のベストプラクティスに沿って、小さく論理的な単位で行う。
+
+Assumption: 今回は `pr-writer` skill と `commit` skill 本体は変更せず、project-local `exec-plan` skill の指示だけを更新する。
+
+## 進捗
+
+- [x] 2026-04-25 23:24+09:00 `exec-plan` / `commit` / `pr-writer` skill の現行契約を確認した。
+- [x] 2026-04-25 23:24+09:00 commit 粒度の一般的なベストプラクティスを外部資料で調査した。
+- [x] 2026-04-25 23:26+09:00 `.codex/skills/exec-plan/SKILL.md` に PR / commit 運用を反映した。
+- [x] 2026-04-25 23:26+09:00 差分と検証結果を確認した。
+- [x] 2026-04-25 23:26+09:00 ExecPlan を `docs/exec-plans/completed/202604252324_exec_plan_skill_pr_commit/` に移した。
+- [x] 2026-04-25 23:30+09:00 review fix loop の採用 finding を修正した。
+- [x] 2026-04-25 23:31+09:00 同じ reviewer set の再確認で `findings なし` を確認した。
+
+## 気づきと発見
+
+Observation: 現行の `exec-plan` skill は commit を「user が commit を依頼した時」または spec-to-PR の自律実行として扱い、PR 作成は具体的に `pr-writer` skill へ委譲していない。
+Evidence:
+    .codex/skills/exec-plan/SKILL.md の実行フロー step 8 / 9 に commit / PR 作成があるが、commit 粒度や pr-writer 委譲は未定義。
+
+Observation: Pro Git は commit 前の `git diff --check` と、各 commit を論理的に分離された changeset にすることを推奨している。
+Evidence:
+    https://git-scm.com/book/tl/v2/Distributed-Git-Contributing-to-a-Project.html
+    Commit Guidelines section に、whitespace check、one commit per issue、useful message、review しやすさ、revert しやすさが説明されている。
+
+Observation: Google Engineering Practices は小さい CL を「1 つの self-contained change」と定義し、review しやすさ、bug 混入リスク低下、rollback のしやすさを理由にしている。
+Evidence:
+    https://google.github.io/eng-practices/review/developer/small-cls.html
+    Small CLs section に、single thing、related tests、reviewer が理解できる情報、refactor と feature / bug fix の分離が説明されている。
+
+Observation: Conventional Commits は commit message に type / optional scope / description を与え、commit の性質を人間と機械に伝える仕様で、複数 type にまたがる場合は可能なら複数 commit に戻ることを推奨している。
+Evidence:
+    https://www.conventionalcommits.org/en/v1.0.0/
+    Summary / Specification / FAQ に、`<type>[optional scope]: <description>`、`feat` / `fix` / `BREAKING CHANGE`、複数 type の場合は multiple commits が説明されている。
+
+Observation: `exec-plan` skill に commit / PR 運用 section を追加し、実行フローと spec-to-PR 契約を更新した。
+Evidence:
+    git diff --stat
+     .codex/skills/exec-plan/SKILL.md | 21 +++++++++++++++++++--
+     1 file changed, 19 insertions(+), 2 deletions(-)
+
+Observation: `mise run verify` は lint と TypeScript compile まで進み、既存の runtime env 不足で `/blog` page data collection が停止した。
+Evidence:
+    mise run verify
+    [lint] Finished in 25.71s
+    [build] ✓ Compiled successfully in 17.7s
+    [build] Error: MICROCMS_API_KEY is not set
+    [build] Error: Failed to collect page data for /blog
+
+Observation: review fix loop では `contract-reviewer` と `ce-reviewer` が同じ P3 finding を出し、採用 finding として修正した。
+Evidence:
+    contract-reviewer: completed ExecPlan に stale な `docs/exec-plans/active/...` path が残っていると指摘。
+    ce-reviewer: completed 移動後の artifact trail として再実行すると現在の ExecPlan を確認できないと指摘。
+    修正後、`具体手順` の diff command を completed path へ更新した。
+
+Observation: review fix loop cycle 1 は同じ reviewer set で未解決 finding なしになった。
+Evidence:
+    contract-reviewer / 019dc50b-aacb-73c0-ba73-012018c9ca7d: findings なし。
+    ce-reviewer / 019dc50b-ab0d-7e00-8da0-ed54d4006462: findings なし。
+
+## 判断記録
+
+Decision: commit 粒度の基準は「小さい」単独ではなく、「論理的に独立・review 可能・revert 可能・検証可能な changeset」として書く。
+Rationale: 行数だけを基準にすると過剰分割や巨大 commit の両方を招くため、Pro Git / Google Engineering Practices / Conventional Commits の共通部分を採用する。
+Date/Author: 2026-04-25 / Codex
+
+Decision: PR 作成は ExecPlan skill から直接 `gh pr create` を指示せず、`pr-writer` skill に委譲する。
+Rationale: PR title/body 生成、既存 PR update、issue なし、UI preview などの専用判断は `pr-writer` skill に集約されているため。
+Date/Author: 2026-04-25 / Codex
+
+Decision: issue が無い場合は blocker にせず、`pr-writer` へ `issueなし` を明示して PR を作成できるようにする。
+Rationale: ユーザーが「issue なしの場合でも」と明示しており、暗黙スキップではなく明示的な no-issue input として扱えば pr-writer の issue 特定契約と衝突しないため。
+Date/Author: 2026-04-25 / Codex
+
+## 依存関係と契約
+
+Dependency: `.codex/skills/exec-plan/SKILL.md`
+Reason: 今回更新する project-local skill。
+Contract: 実行フロー、spec-to-PR 契約、完了条件を新方針に合わせる。
+
+Dependency: `commit` skill
+Reason: commit 実行の正本。
+Contract: ExecPlan skill は commit 実行時に `commit` skill を使うよう指示し、message 形式や staging の詳細を重複定義しない。
+
+Dependency: `pr-writer` skill
+Reason: PR 作成・更新の正本。
+Contract: ExecPlan skill は PR 作成時に `pr-writer` skill を使うよう指示し、PR body 生成手順を重複定義しない。
+
+## 具体手順
+
+1. `.codex/skills/exec-plan/SKILL.md` に commit 粒度 section を追加する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        apply_patch
+    Expected outcome:
+        commit skill を使う条件と、commit 粒度の基準が明文化される。
+
+2. `.codex/skills/exec-plan/SKILL.md` の実行フロー / spec-to-PR 契約を更新する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        apply_patch
+    Expected outcome:
+        PR 作成が `pr-writer` skill 委譲になり、issue なしでも自動作成できる。
+
+3. 差分を確認する。
+
+    Working directory:
+        <repo-root>
+    Command:
+        git diff -- .codex/skills/exec-plan/SKILL.md docs/exec-plans/completed/202604252324_exec_plan_skill_pr_commit/exec-plan.md
+    Expected outcome:
+        変更は exec-plan skill と本 ExecPlan のみに限定される。
+
+## 検証と受け入れ条件
+
+Input: `git diff --check`
+Observe: whitespace error はない。untracked ExecPlan も `git diff --no-index --check /dev/null docs/exec-plans/completed/202604252324_exec_plan_skill_pr_commit/exec-plan.md` で whitespace error を出していない。
+Failure signal: whitespace error が出る。
+
+Input: 対象差分の確認。
+Observe: `exec-plan` skill に、`commit` skill による小さな論理 commit、`pr-writer` skill による PR 作成、`issueなし` での PR 作成継続が書かれている。
+Failure signal: commit / PR 手順が別 skill と重複する、または issue なしが blocker のまま残る。
+
+Input: `mise run verify`
+Observe: lint は成功し、build は TypeScript compile 後の `/blog` page data collection で `MICROCMS_API_KEY is not set` により失敗した。差分起因の failure は観測されていない。
+Failure signal: lint failure、または `MICROCMS_API_KEY` 以外の未説明 build failure が残る。
+
+## 冪等性と復旧
+
+1. 変更は skill 文書への additive / localized な追記に留める。
+2. 同じ内容が重複した場合は `git diff` で重複 section を確認して整理する。
+3. 外部 service、secret、app runtime は変更しない。
+4. commit / PR 実行の詳細は専用 skill を正本にし、ここでは委譲契約だけを書く。
+5. temporary file、dev server、生成物は作らない。
+
+## 未完了事項
+
+`mise run verify` の build は `MICROCMS_API_KEY` 未設定により完了していない。lint と TypeScript compile は通過した。今回の変更は skill 文書と ExecPlan のみ。
+
+Change note: 2026-04-25 23:31+09:00 review fix loop cycle 1 の reviewer verdict を記録した。


### PR DESCRIPTION
## 概要
今後の開発で t-wada の TDD を前提にできるよう、repo 固有のテスト規約を追加します。実際の test runner、test dependency、test file、CI pipeline はまだ導入しません。

## 背景・動機
開発手順の前提を先に揃え、テスト基盤導入前でも test list / acceptance を起点に小さく実装できるようにするためです。

## やったこと
### 開発規約
- `docs/conventions.md` に Testing / TDD policy を追加し、Red → Green → Refactor の進め方を明文化しました。
- テスト基盤がない間は、ExecPlan または着手前メモに test list / acceptance を置き、観測可能に満たした状態を Green 相当として扱うことを定義しました。
- 将来のテスト基盤導入後に、振る舞い優先のテスト、最小実装、Green 中の refactor を守る方針を追加しました。

### Agent 参照
- `AGENTS.md` から Testing / TDD policy へ辿れる短い参照を追加しました。
- ExecPlan に作業範囲、review fix loop、検証結果を記録しました。

## 確認方法
- `git diff --check`
- `mise run verify`
  - lint は成功
  - build は既存の `MICROCMS_API_KEY is not set` で `/blog` の page data collection が停止

## 影響範囲とリスク
- 変更は docs / agent contract のみです。
- 実テスト、依存、CI、`mise run verify` の hard guard は変更していません。
- build 完了確認は `MICROCMS_API_KEY` 未設定のため未完了です。

## 関連Issue
なし
