### PR TITLE
test(site): テスト基盤と公開 route の回帰テストを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ published: true
 mise run verify
 ```
 
-`mise run verify` は lint と build を順に実行する唯一の hard guard です。
+`mise run verify` は lint、unit test、build、E2E を順に実行する唯一の hard guard です。

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -103,19 +103,22 @@ hidden runtime、pipeline directory、別形式の task artifact は増やしま
 「動作するきれいなコード」を目指し、テストリストから 1 つ選び、Red → Green →
 Refactor を小さく回す進め方を指します。
 
-現時点では test runner、test dependency、test file は未導入です。これらは別タスクで
-明示的に導入するまで追加しません。`mise run verify` は引き続き唯一の hard guard です。
+テスト基盤は `web/` に導入済みです。unit test は `Vitest` を使い、
+`web/src/**/*.test.{ts,tsx}` に置きます。E2E test は `Playwright` を使い、
+`web/e2e/*.spec.ts` に置きます。`mise run verify` は引き続き唯一の hard guard
+であり、`web/` で `pnpm lint && pnpm test && pnpm build && pnpm test:e2e` を
+順に実行します。
 
-テスト基盤がない間も、TDD の意図は維持します。
+テストを書く前に、TDD の意図を維持します。
 
 - 実装前に、期待する振る舞いを test list または acceptance として明示する。
 - バグ修正では、先に失敗している振る舞いと期待する成功状態を書く。
 - 実装は観測可能な振る舞いを 1 つずつ変え、検証結果を最終報告または Superpowers spec / plan に残す。
 - test list / acceptance は、Superpowers spec / plan がある場合は該当 artifact に、ない小変更ではユーザー要求または着手前メモに置く。
-- Green 相当とは、明示した test list / acceptance を観測可能に満たした状態を指す。
+- Green 相当とは、追加した test または明示した acceptance を観測可能に満たした状態を指す。
 - Green 相当の状態を確認してから refactor する。挙動変更と refactor を混ぜない。
 
-テスト基盤を導入した後は、次を守ります。
+テストでは次を守ります。
 
 - user-visible behavior、public API、共有関数の契約、regression を優先してテストする。
 - 実装前に失敗するテストを書き、最小実装で Green にする。

--- a/docs/superpowers/plans/2026-05-09-test-expansion.md
+++ b/docs/superpowers/plans/2026-05-09-test-expansion.md
@@ -1,0 +1,1100 @@
+# Test Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `Vitest` と `Playwright` を導入し、content 境界と主要 route の回帰を `mise run verify` で検出できるようにする。
+
+**Architecture:** Unit test は `web/src/**/*.test.ts` に置き、`ContentSource` と `ArticleBlock` の契約を高速に検証する。E2E は `web/e2e/*.spec.ts` に置き、production build 後の Next.js server を Playwright から確認する。`mise run verify` は lint、unit test、build、E2E を含む hard guard に拡張する。
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Vitest, Playwright, pnpm, mise.
+
+---
+
+## File Structure
+
+**Create**
+
+- `web/vitest.config.ts`: Vitest の test 対象、実行環境、CSS module の扱いを定義する。
+- `web/src/lib/content/blocks.test.ts`: Markdown 本文から `ArticleBlock[]` への変換を検証する。
+- `web/src/lib/content/markdown-source.test.ts`: fixture Markdown を一時 directory に書き、`ContentSource` 契約を検証する。
+- `web/src/components/site/ArticleContent.test.tsx`: `ArticleContent` の代表 block 描画と linkCard protocol guard を検証する。
+- `web/playwright.config.ts`: Playwright の test directory、production server、Chromium project を定義する。
+- `web/e2e/content.spec.ts`: `/`, `/notes`, `/notes/[slug]`, `/blog`, `/blog/[articleId]` の主要挙動を検証する。
+
+**Modify**
+
+- `web/package.json`: `test`, `test:e2e` script と `vitest`, `@playwright/test` dev dependency を追加する。
+- `web/pnpm-lock.yaml`: dependency 追加に合わせて更新する。
+- `web/src/lib/content/markdown-source.ts`: 任意の notes directory から `ContentSource` を作る `createMarkdownSource` を export する。
+- `mise.toml`: `test`, `test:e2e` task を追加し、`verify` の hard guard に組み込む。
+
+---
+
+### Task 1: Vitest 基盤と ArticleBlock parser regression
+
+**Files:**
+
+- Modify: `web/package.json`
+- Modify: `web/pnpm-lock.yaml`
+- Create: `web/vitest.config.ts`
+- Create: `web/src/lib/content/blocks.test.ts`
+
+- [ ] **Step 1: Vitest を dev dependency に追加する**
+
+Run:
+
+```bash
+pnpm add -D vitest
+```
+
+Expected:
+
+- `web/package.json` の `devDependencies` に `vitest` が追加される。
+- `web/pnpm-lock.yaml` が更新される。
+
+- [ ] **Step 2: `test` script を追加する**
+
+Edit `web/package.json` の `scripts` を次の形にする。既存の `dev`, `build`, `start`, `lint`, `format` は維持する。
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "if [ \"$ANALYZE\" = \"true\" ]; then next build --webpack; else next build; fi",
+    "start": "next start",
+    "lint": "eslint '**/*.@(js|ts|tsx)'",
+    "test": "vitest run",
+    "format": "prettier --write . && pnpm lint --fix"
+  }
+}
+```
+
+Expected:
+
+- `pnpm test` が Vitest を headless で実行する。
+
+- [ ] **Step 3: Vitest config を作成する**
+
+Create `web/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+    restoreMocks: true,
+    watch: false,
+  },
+});
+```
+
+Expected:
+
+- Unit test は `web/src/**/*.test.ts` と `web/src/**/*.test.tsx` だけを対象にする。
+- E2E の `web/e2e/*.spec.ts` は Vitest 対象に入らない。
+
+- [ ] **Step 4: `parseArticleBlocks` の regression test を書く**
+
+Create `web/src/lib/content/blocks.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { parseArticleBlocks } from "./blocks";
+
+describe("parseArticleBlocks", () => {
+  it("parses core Markdown blocks into ArticleBlock objects", () => {
+    const blocks = parseArticleBlocks(`# Title
+
+Intro line
+continued line
+
+## Section
+
+- First
+- Second
+
+> Quote line
+> continued quote
+
+\`\`\`ts
+const value = "ok";
+\`\`\`
+
+![Alt text](/image.png "Caption text")`);
+
+    expect(blocks).toEqual([
+      { kind: "heading", level: 1, text: "Title" },
+      { kind: "paragraph", text: "Intro line continued line" },
+      { kind: "heading", level: 2, text: "Section" },
+      { kind: "list", items: ["First", "Second"] },
+      { kind: "quote", text: "Quote line continued quote" },
+      { kind: "code", code: 'const value = "ok";', language: "ts" },
+      {
+        kind: "image",
+        asset: {
+          id: "/image.png",
+          src: "/image.png",
+          alt: "Alt text",
+        },
+        caption: "Caption text",
+      },
+    ]);
+  });
+
+  it("parses note and warning callouts", () => {
+    expect(
+      parseArticleBlocks(`:::callout
+Note body
+:::
+
+:::callout warning
+Warning body
+:::`),
+    ).toEqual([
+      { kind: "callout", tone: "note", text: "Note body" },
+      { kind: "callout", tone: "warning", text: "Warning body" },
+    ]);
+  });
+
+  it("rejects unclosed callout blocks", () => {
+    expect(() => parseArticleBlocks(":::callout\nMissing close")).toThrow(
+      "Unclosed callout block",
+    );
+  });
+
+  it("rejects unclosed code blocks", () => {
+    expect(() => parseArticleBlocks("```ts\nconst value = 1;")).toThrow(
+      "Unclosed code block",
+    );
+  });
+
+  it("rejects unsupported custom block syntax", () => {
+    expect(() => parseArticleBlocks("::link-card\nhttps://example.com")).toThrow(
+      "Unsupported custom block syntax: ::link-card",
+    );
+  });
+});
+```
+
+Expected:
+
+- 既存 parser の代表的な成功条件と失敗条件が固定される。
+
+- [ ] **Step 5: Parser test を実行する**
+
+Run:
+
+```bash
+pnpm test -- src/lib/content/blocks.test.ts
+```
+
+Expected:
+
+- `blocks.test.ts` が PASS する。
+
+- [ ] **Step 6: Task 1 を commit する**
+
+Use the `commit` skill. Target files:
+
+```text
+web/package.json
+web/pnpm-lock.yaml
+web/vitest.config.ts
+web/src/lib/content/blocks.test.ts
+```
+
+Candidate message:
+
+```text
+test(content): ArticleBlock parser の回帰テストを追加
+```
+
+Expected:
+
+- Vitest 基盤と parser regression test が 1 commit になる。
+
+---
+
+### Task 2: ContentSource を fixture で検証する
+
+**Files:**
+
+- Modify: `web/src/lib/content/markdown-source.ts`
+- Create: `web/src/lib/content/markdown-source.test.ts`
+
+- [ ] **Step 1: `createMarkdownSource` を前提にした failing test を書く**
+
+Create `web/src/lib/content/markdown-source.test.ts`:
+
+```ts
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMarkdownSource } from "./markdown-source";
+
+const createdDirectories: string[] = [];
+
+const makeNotesDirectory = async (
+  files: Record<string, string>,
+): Promise<string> => {
+  const directory = await mkdtemp(path.join(tmpdir(), "yona-notes-"));
+  createdDirectories.push(directory);
+
+  await Promise.all(
+    Object.entries(files).map(([fileName, content]) =>
+      writeFile(path.join(directory, fileName), content),
+    ),
+  );
+
+  return directory;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories.splice(0).map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  );
+});
+
+const publishedNew = `---
+title: New Note
+slug: new-note
+date: 2026-05-02
+type: note
+description: New description
+published: true
+---
+# New Note
+
+New body`;
+
+const publishedOld = `---
+title: Old Article
+slug: old-article
+date: 2026-05-01
+type: article
+description: Old description
+published: true
+---
+Old body`;
+
+const draft = `---
+title: Draft Log
+slug: draft-log
+date: 2026-05-03
+type: log
+description: Draft description
+published: false
+---
+Draft body`;
+
+describe("createMarkdownSource", () => {
+  it("returns only published articles sorted by publishedAt descending", async () => {
+    const directory = await makeNotesDirectory({
+      "new.md": publishedNew,
+      "old.md": publishedOld,
+      "draft.md": draft,
+    });
+    const source = createMarkdownSource(directory);
+
+    const articles = await source.getAllArticles();
+
+    expect(articles.map((article) => article.slug)).toEqual([
+      "new-note",
+      "old-article",
+    ]);
+    expect(articles[0]).toMatchObject({
+      id: "new-note",
+      title: "New Note",
+      description: "New description",
+      publishedAt: "2026-05-02",
+      kind: "note",
+      isPublished: true,
+      blocks: [{ kind: "paragraph", text: "New body" }],
+    });
+  });
+
+  it("returns articles by slug and omits unpublished slugs", async () => {
+    const directory = await makeNotesDirectory({
+      "new.md": publishedNew,
+      "draft.md": draft,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getArticleSlugs()).resolves.toEqual(["new-note"]);
+    await expect(source.getArticleBySlug("new-note")).resolves.toMatchObject({
+      slug: "new-note",
+    });
+    await expect(source.getArticleBySlug("draft-log")).resolves.toBeNull();
+    await expect(source.getArticleBySlug("missing")).resolves.toBeNull();
+  });
+
+  it("rejects Markdown without valid frontmatter", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid.md": "No frontmatter",
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Missing frontmatter in invalid.md",
+    );
+  });
+
+  it("rejects invalid frontmatter shape", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid.md": `---
+title: Invalid
+slug: invalid
+date: 2026-05-02
+type: note
+description: Missing published
+---
+Body`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Invalid frontmatter shape in invalid.md",
+    );
+  });
+
+  it("rejects unsupported article kinds", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid-kind.md": `---
+title: Invalid Kind
+slug: invalid-kind
+date: 2026-05-02
+type: diary
+description: Invalid kind
+published: true
+---
+Body`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Invalid article kind in invalid-kind.md: diary",
+    );
+  });
+
+  it("rejects unsupported custom block syntax inside articles", async () => {
+    const directory = await makeNotesDirectory({
+      "custom.md": `---
+title: Custom Block
+slug: custom-block
+date: 2026-05-02
+type: note
+description: Custom block
+published: true
+---
+::unknown
+value`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Unsupported custom block syntax: ::unknown",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Test が export 不足で失敗することを確認する**
+
+Run:
+
+```bash
+pnpm test -- src/lib/content/markdown-source.test.ts
+```
+
+Expected:
+
+- FAIL。
+- Error includes `No matching export` または `createMarkdownSource` が export されていない旨の message。
+
+- [ ] **Step 3: `markdown-source.ts` に test seam を追加する**
+
+Replace `web/src/lib/content/markdown-source.ts` with:
+
+```ts
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { cache } from "react";
+
+import { parseArticleBlocks } from "./blocks";
+import type { Article, ArticleKind, ContentSource } from "./types";
+
+type ArticleFrontmatter = {
+  title: string;
+  slug: string;
+  date: string;
+  type: ArticleKind;
+  description: string;
+  published: boolean;
+  updatedAt?: string;
+};
+
+const defaultNotesDirectory = path.join(process.cwd(), "content", "notes");
+const articleKinds = new Set<ArticleKind>(["article", "note", "log"]);
+
+const normalizeArticleContent = (content: string, title: string): string => {
+  const trimmed = content.trim();
+  const firstLineEnd = trimmed.indexOf("\n");
+  const firstLine = firstLineEnd === -1 ? trimmed : trimmed.slice(0, firstLineEnd);
+
+  if (firstLine.trim() !== `# ${title}`) {
+    return trimmed;
+  }
+
+  return firstLineEnd === -1 ? "" : trimmed.slice(firstLineEnd + 1).trimStart();
+};
+
+const parseFrontmatterValue = (value: string): string | boolean => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value;
+};
+
+const parseFrontmatter = (
+  source: string,
+  fileName: string,
+): { data: ArticleFrontmatter; content: string } => {
+  const match = source.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+
+  if (!match) {
+    throw new Error(`Missing frontmatter in ${fileName}`);
+  }
+
+  const [, frontmatter, content] = match;
+  const entries = frontmatter.split("\n").map((line) => {
+    const separatorIndex = line.indexOf(":");
+
+    if (separatorIndex === -1) {
+      throw new Error(`Invalid frontmatter line in ${fileName}: ${line}`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    return [key, parseFrontmatterValue(value)] as const;
+  });
+
+  const data = Object.fromEntries(entries);
+
+  if (
+    typeof data.title !== "string" ||
+    typeof data.slug !== "string" ||
+    typeof data.date !== "string" ||
+    typeof data.type !== "string" ||
+    typeof data.description !== "string" ||
+    typeof data.published !== "boolean"
+  ) {
+    throw new Error(`Invalid frontmatter shape in ${fileName}`);
+  }
+
+  if (!articleKinds.has(data.type as ArticleKind)) {
+    throw new Error(`Invalid article kind in ${fileName}: ${data.type}`);
+  }
+
+  return {
+    data: {
+      title: data.title,
+      slug: data.slug,
+      date: data.date,
+      type: data.type as ArticleKind,
+      description: data.description,
+      published: data.published,
+      updatedAt: typeof data.updatedAt === "string" ? data.updatedAt : undefined,
+    },
+    content: normalizeArticleContent(content, data.title),
+  };
+};
+
+export const createMarkdownSource = (
+  notesDirectory = defaultNotesDirectory,
+): ContentSource => {
+  const getAllMarkdownArticles = cache(async (): Promise<Article[]> => {
+    const fileNames = await fs.readdir(notesDirectory);
+    const articles = await Promise.all(
+      fileNames
+        .filter((fileName) => fileName.endsWith(".md"))
+        .map(async (fileName) => {
+          const source = await fs.readFile(path.join(notesDirectory, fileName), "utf8");
+          const { data, content } = parseFrontmatter(source, fileName);
+
+          return {
+            id: data.slug,
+            slug: data.slug,
+            title: data.title,
+            description: data.description,
+            publishedAt: data.date,
+            updatedAt: data.updatedAt,
+            kind: data.type,
+            isPublished: data.published,
+            blocks: parseArticleBlocks(content),
+          } satisfies Article;
+        }),
+    );
+
+    return articles
+      .filter((article) => article.isPublished)
+      .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  });
+
+  return {
+    getAllArticles: getAllMarkdownArticles,
+    async getArticleBySlug(slug) {
+      const articles = await getAllMarkdownArticles();
+      return articles.find((article) => article.slug === slug) ?? null;
+    },
+    async getArticleSlugs() {
+      const articles = await getAllMarkdownArticles();
+      return articles.map((article) => article.slug);
+    },
+  };
+};
+
+export const markdownSource = createMarkdownSource();
+```
+
+Expected:
+
+- Production export `markdownSource` の挙動は維持される。
+- Test は temporary directory を渡して production content から分離できる。
+
+- [ ] **Step 4: ContentSource test を実行する**
+
+Run:
+
+```bash
+pnpm test -- src/lib/content/markdown-source.test.ts
+```
+
+Expected:
+
+- `markdown-source.test.ts` が PASS する。
+
+- [ ] **Step 5: Content unit tests をまとめて実行する**
+
+Run:
+
+```bash
+pnpm test -- src/lib/content
+```
+
+Expected:
+
+- `blocks.test.ts` と `markdown-source.test.ts` が PASS する。
+
+- [ ] **Step 6: Task 2 を commit する**
+
+Use the `commit` skill. Target files:
+
+```text
+web/src/lib/content/markdown-source.ts
+web/src/lib/content/markdown-source.test.ts
+```
+
+Candidate message:
+
+```text
+test(content): ContentSource の契約テストを追加
+```
+
+Expected:
+
+- `createMarkdownSource` seam と content source tests が 1 commit になる。
+
+---
+
+### Task 3: ArticleContent renderer 契約を固定する
+
+**Files:**
+
+- Create: `web/src/components/site/ArticleContent.test.tsx`
+
+- [ ] **Step 1: Renderer regression test を書く**
+
+Create `web/src/components/site/ArticleContent.test.tsx`:
+
+```tsx
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { ArticleBlock } from "../../lib/content";
+import { ArticleContent } from "./ArticleContent";
+
+describe("ArticleContent", () => {
+  it("renders representative article blocks", () => {
+    const blocks: ArticleBlock[] = [
+      { kind: "heading", level: 2, text: "Section" },
+      { kind: "paragraph", text: "Paragraph body" },
+      { kind: "list", items: ["First", "Second"] },
+      { kind: "quote", text: "Quote body" },
+      { kind: "code", code: "const value = 1;", language: "ts" },
+      {
+        kind: "image",
+        asset: { id: "image", src: "/image.png", alt: "Image alt" },
+        caption: "Image caption",
+      },
+      { kind: "callout", tone: "warning", text: "Warning body" },
+      {
+        kind: "linkCard",
+        title: "Example",
+        url: "https://example.com/path",
+        description: "Example description",
+      },
+      {
+        kind: "gallery",
+        images: [{ id: "gallery", src: "/gallery.png", alt: "Gallery alt" }],
+      },
+    ];
+
+    const markup = renderToStaticMarkup(<ArticleContent blocks={blocks} />);
+
+    expect(markup).toContain("<h2>Section</h2>");
+    expect(markup).toContain("<p>Paragraph body</p>");
+    expect(markup).toContain("<li>First</li>");
+    expect(markup).toContain("<blockquote>Quote body</blockquote>");
+    expect(markup).toContain("<code>const value = 1;</code>");
+    expect(markup).toContain('alt="Image alt"');
+    expect(markup).toContain("<figcaption>Image caption</figcaption>");
+    expect(markup).toContain("Warning body");
+    expect(markup).toContain('href="https://example.com/path"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('alt="Gallery alt"');
+  });
+
+  it("rejects unsafe linkCard protocols during render", () => {
+    const blocks: ArticleBlock[] = [
+      {
+        kind: "linkCard",
+        title: "Unsafe",
+        url: "javascript:alert(1)",
+      },
+    ];
+
+    expect(() => renderToStaticMarkup(<ArticleContent blocks={blocks} />)).toThrow(
+      "Unsupported linkCard URL protocol: javascript:",
+    );
+  });
+});
+```
+
+Expected:
+
+- Renderer が代表 block を React escaping 前提で描画することが固定される。
+- `javascript:` linkCard が render 時に失敗することが固定される。
+
+- [ ] **Step 2: Renderer test を実行する**
+
+Run:
+
+```bash
+pnpm test -- src/components/site/ArticleContent.test.tsx
+```
+
+Expected:
+
+- `ArticleContent.test.tsx` が PASS する。
+
+- [ ] **Step 3: Unit tests 全体を実行する**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected:
+
+- `blocks.test.ts`, `markdown-source.test.ts`, `ArticleContent.test.tsx` が PASS する。
+
+- [ ] **Step 4: Task 3 を commit する**
+
+Use the `commit` skill. Target file:
+
+```text
+web/src/components/site/ArticleContent.test.tsx
+```
+
+Candidate message:
+
+```text
+test(site): 記事 renderer の契約テストを追加
+```
+
+Expected:
+
+- Renderer regression test が 1 commit になる。
+
+---
+
+### Task 4: Playwright E2E で公開 route を固定する
+
+**Files:**
+
+- Modify: `web/package.json`
+- Modify: `web/pnpm-lock.yaml`
+- Create: `web/playwright.config.ts`
+- Create: `web/e2e/content.spec.ts`
+
+- [ ] **Step 1: Playwright を dev dependency に追加する**
+
+Run:
+
+```bash
+pnpm add -D @playwright/test
+```
+
+Expected:
+
+- `web/package.json` の `devDependencies` に `@playwright/test` が追加される。
+- `web/pnpm-lock.yaml` が更新される。
+
+- [ ] **Step 2: Chromium browser を導入する**
+
+Run:
+
+```bash
+pnpm exec playwright install chromium
+```
+
+Expected:
+
+- Chromium browser が Playwright の実行環境に導入される。
+- すでに導入済みの場合は、Playwright が再利用できる状態を返す。
+
+- [ ] **Step 3: `test:e2e` script を追加する**
+
+Edit `web/package.json` の `scripts` を次の形にする。Task 1 の `test` script は維持する。
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "if [ \"$ANALYZE\" = \"true\" ]; then next build --webpack; else next build; fi",
+    "start": "next start",
+    "lint": "eslint '**/*.@(js|ts|tsx)'",
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "format": "prettier --write . && pnpm lint --fix"
+  }
+}
+```
+
+Expected:
+
+- `pnpm test:e2e` が Playwright を実行する。
+
+- [ ] **Step 4: Playwright config を作成する**
+
+Create `web/playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 3100);
+const baseUrl = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  reporter: "list",
+  use: {
+    baseURL: baseUrl,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
+    url: baseUrl,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});
+```
+
+Expected:
+
+- Playwright は production server を `127.0.0.1:3100` で起動する。
+- `PLAYWRIGHT_PORT` を指定した時はその port を使う。
+
+- [ ] **Step 5: E2E test を書く**
+
+Create `web/e2e/content.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test("home page exposes the main notes entry points", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Hello, I'm yona!" }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Notes" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+});
+
+test("notes page lists published notes and hides drafts", async ({ page }) => {
+  await page.goto("/notes");
+
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "ブロックスタイルテスト" }),
+  ).toHaveCount(0);
+});
+
+test("note detail renders metadata and representative blocks", async ({ page }) => {
+  await page.goto("/notes/site-renewal");
+
+  await expect(
+    page.getByRole("heading", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+  await expect(page.getByText("2026.04.26")).toBeVisible();
+  await expect(page.getByText("ノート")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "サイトについて" }),
+  ).toBeVisible();
+  await expect(page.getByText("この note の下書きは")).toBeVisible();
+});
+
+test("legacy blog routes redirect to notes", async ({ page }) => {
+  await page.goto("/blog");
+  await expect(page).toHaveURL(/\/notes$/);
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+
+  await page.goto("/blog/anything");
+  await expect(page).toHaveURL(/\/notes$/);
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+});
+```
+
+Expected:
+
+- E2E は公開記事表示、未公開記事の非表示、記事 detail、legacy redirect を確認する。
+- screenshot や visual regression は含めない。
+
+- [ ] **Step 6: Build 後に E2E を実行する**
+
+Run:
+
+```bash
+pnpm build
+pnpm test:e2e
+```
+
+Expected:
+
+- `pnpm build` が PASS する。
+- `pnpm test:e2e` が Chromium project で PASS する。
+
+- [ ] **Step 7: Task 4 を commit する**
+
+Use the `commit` skill. Target files:
+
+```text
+web/package.json
+web/pnpm-lock.yaml
+web/playwright.config.ts
+web/e2e/content.spec.ts
+```
+
+Candidate message:
+
+```text
+test(e2e): 公開 route の Playwright テストを追加
+```
+
+Expected:
+
+- Playwright config と E2E tests が 1 commit になる。
+
+---
+
+### Task 5: `mise run verify` に test を組み込む
+
+**Files:**
+
+- Modify: `mise.toml`
+
+- [ ] **Step 1: root task に `test` と `test:e2e` を追加する**
+
+Edit `mise.toml`:
+
+```toml
+[tasks.install]
+description = "Install dependencies"
+run = "pnpm install"
+dir = "{{config_root}}/web"
+
+[tasks.dev]
+description = "Start development server"
+run = "pnpm dev"
+dir = "{{config_root}}/web"
+
+[tasks.build]
+description = "Production build"
+run = "pnpm build"
+dir = "{{config_root}}/web"
+
+[tasks.start]
+description = "Start production server"
+run = "pnpm start"
+dir = "{{config_root}}/web"
+
+[tasks.lint]
+description = "Run ESLint"
+run = "pnpm lint"
+dir = "{{config_root}}/web"
+
+[tasks.test]
+description = "Run unit tests"
+run = "pnpm test"
+dir = "{{config_root}}/web"
+
+[tasks."test:e2e"]
+description = "Run E2E tests"
+depends = ["build"]
+run = "pnpm test:e2e"
+dir = "{{config_root}}/web"
+
+[tasks.format]
+description = "Format code with Prettier and fix lint"
+run = "pnpm format"
+dir = "{{config_root}}/web"
+
+[tasks.verify]
+description = "Run all verification checks"
+depends = ["lint", "test", "test:e2e"]
+```
+
+Expected:
+
+- `mise run test` は unit tests を実行する。
+- `mise run test:e2e` は `build` 後に E2E を実行する。
+- `mise run verify` は lint、unit test、build、E2E を含む。
+
+- [ ] **Step 2: root task を個別に確認する**
+
+Run:
+
+```bash
+mise run test
+```
+
+Expected:
+
+- Vitest tests が PASS する。
+
+Run:
+
+```bash
+mise run test:e2e
+```
+
+Expected:
+
+- `build` が先に実行され、Playwright E2E が PASS する。
+
+- [ ] **Step 3: hard guard を実行する**
+
+Run:
+
+```bash
+mise run verify
+```
+
+Expected:
+
+- `lint`, `test`, `build`, `test:e2e` が PASS する。
+- Playwright browser が不足している場合は `pnpm exec playwright install chromium` を実行し、同じ `mise run verify` を再実行する。
+
+- [ ] **Step 4: Task 5 を commit する**
+
+Use the `commit` skill. Target file:
+
+```text
+mise.toml
+```
+
+Candidate message:
+
+```text
+test(verify): verify に unit と E2E を組み込む
+```
+
+Expected:
+
+- root verify gate の変更が 1 commit になる。
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: 全差分を確認する**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+- 未 commit の差分がない、または最終報告用の計画更新だけが残っている。
+
+- [ ] **Step 2: hard guard を再実行する**
+
+Run:
+
+```bash
+mise run verify
+```
+
+Expected:
+
+- exit 0。
+- `lint`, `test`, `build`, `test:e2e` が実行済みである。
+
+- [ ] **Step 3: project-local review を実行する**
+
+Use the project-local `review` skill for the final diff range.
+
+Expected:
+
+- review verdict が APPROVE。
+- 未解決 finding が残っていない。
+- review summary には reviewer ids、verdict、未解決 finding、未検証範囲、実行した verification command を含める。
+
+- [ ] **Step 4: PR 作成または更新へ進む**
+
+Use the project-local `pr-writer` skill when publishing this work.
+
+Expected:
+
+- PR body は test expansion の目的、実行した verification、review verdict を含む。
+- `pr-writer` の Phase 6 以外で `gh pr create` / `gh pr edit` を直接実行しない。

--- a/docs/superpowers/specs/2026-05-09-test-expansion-design.md
+++ b/docs/superpowers/specs/2026-05-09-test-expansion-design.md
@@ -1,0 +1,102 @@
+# テスト拡充設計
+
+## 背景
+
+yona.dev は `web/content/notes/*.md` を公開コンテンツの正本にし、`ContentSource` 境界を通して `Article` と `ArticleBlock[]` を route / renderer に渡している。現在の `mise run verify` は `lint` と `build` だけで、test runner、test dependency、test file は未導入である。
+
+今回の目的は、最近増えた content 境界と公開 route の回帰を決定的に検出できるようにすることである。特に、Markdown parser、frontmatter、公開記事 filter、slug 生成、記事本文 block、`/blog` redirect を `verify` の中で確認できる状態にする。
+
+## 採用方針
+
+第一段階では `Vitest + Playwright` を採用する。
+
+- `Vitest`: `web/src/lib/content/` の純粋ロジックと content source 契約を高速に検証する。
+- `Playwright`: production build 後の主要 route と記事表示の挙動を検証する。
+- `mise run verify`: `lint`, `test`, `build`, `test:e2e` を順に実行する hard guard に拡張する。
+
+`Testing Library` と screenshot / visual regression は今回の主系統にしない。component 単位の UI test や視覚差分は、記事 UI の回帰が増えた段階で別の設計に分ける。
+
+## 対象範囲
+
+対象は `web/` のテスト基盤と最初の回帰テストである。
+
+- `parseArticleBlocks` の block 変換と失敗条件
+- Markdown frontmatter の検証
+- `published: false` の除外
+- 公開記事の日付降順 sort
+- slug 一覧と slug detail の契約
+- 本文先頭の `# {title}` 除去
+- `ArticleContent` が代表 block を安全に描画できること
+- `/`, `/notes`, `/notes/[slug]`, `/blog`, `/blog/[articleId]` の主要挙動
+
+対象外は次の通り。
+
+- screenshot / visual regression
+- CMS 本体や Notion sync の test
+- 外部 network を使う test
+- browser ごとの差分検証
+- coverage 閾値の導入
+- `dangerouslySetInnerHTML` を前提にした HTML snapshot
+
+## Unit Test 設計
+
+Unit test は `web/src/**/*.test.ts` に置く。最初の中心は `web/src/lib/content/blocks.ts` と `web/src/lib/content/markdown-source.ts` である。
+
+`parseArticleBlocks` は次を確認する。
+
+- 見出し、段落、リスト、引用、コード、画像を `ArticleBlock[]` に変換する。
+- `:::callout` を `note` / `warning` として変換する。
+- 閉じていない callout と code block は失敗する。
+- 未対応の `::` custom syntax は失敗する。
+
+`markdown-source.ts` は production の `web/content/notes/*.md` へ直接依存しすぎないよう、任意の notes directory から `ContentSource` を作る内部関数を追加して検証する。公開 export は今のまま既定の `content/notes` を読む。
+
+Fixture は unit test 用に分離する。公開記事、未公開記事、invalid frontmatter、未知 custom block を含め、content source の成功条件と失敗条件を明示する。
+
+## E2E 設計
+
+E2E は `web/e2e/*.spec.ts` に置き、`pnpm build` 後の production server を Playwright から検証する。fixture は差し替えず、実際の `web/content/notes` を使う。
+
+確認する route は次の通り。
+
+- `/`: 200 で開き、主要な個人サイト導線が見える。
+- `/notes`: 200 で開き、公開記事が一覧に出る。
+- `/notes/site-renewal`: 200 で開き、記事 title、種別、日付、代表 block が見える。
+- `/blog`: `/notes` へ redirect する。
+- `/blog/anything`: `/notes` へ redirect する。
+
+E2E は smoke だけにしない。記事一覧に未公開記事が出ないこと、記事本文が block renderer 経由で表示されること、旧 `/blog` 系 route が `/notes` に集約されることまで確認する。
+
+## Script と Verify
+
+`web/package.json` に次の script を追加する。
+
+- `test`: Vitest を headless で実行する。
+- `test:e2e`: Playwright test を実行する。
+
+root の `mise.toml` は `verify` の依存に `test` と `test:e2e` を追加する。順序は `lint -> test -> build -> test:e2e` とする。unit test を先に実行して content logic の失敗を早く返し、E2E は build 済み成果物で route と static generation を確認する。
+
+Playwright の web server は `pnpm start` を使う。既定 port が衝突する場合は Playwright 側の設定で専用 port を指定し、test 実行中だけ production server を起動する。
+
+## 失敗時の扱い
+
+Unit test の失敗は content 変換、frontmatter、記事公開条件の不一致として扱う。E2E の失敗は production build 後の route、redirect、記事表示の不一致として扱う。
+
+`mise run verify` が失敗した場合、どの script で落ちたかを報告できる構成にする。環境依存で Playwright browser の導入が不足している場合は、失敗 command、原因、未検証範囲を明示し、依存導入の手順を計画側に残す。
+
+## 成功条件
+
+- `web/` に Vitest と Playwright の設定が追加されている。
+- content parser と content source の代表的な成功条件、失敗条件が unit test で固定されている。
+- 主要 route と `/blog` redirect が E2E で固定されている。
+- `mise run verify` が `lint`, `test`, `build`, `test:e2e` を含む hard guard になっている。
+- テスト用 fixture と production content の責務が分かれている。
+- 外部 network、secret、Notion API に依存しない。
+
+## 承認された判断
+
+- テスト基盤は `Vitest + Playwright` とする。
+- E2E は smoke だけでなく、記事一覧、記事本文 block、metadata 相当の表示、未公開記事の非表示、`/blog` redirect を確認する。
+- screenshot / visual regression は今回の対象外とする。
+- unit test は fixture を使い、E2E は実際の `web/content/notes` と production build を使う。
+- `mise run verify` に unit test と E2E を組み込む。

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,17 @@ description = "Run ESLint"
 run = "pnpm lint"
 dir = "{{config_root}}/web"
 
+[tasks.test]
+description = "Run unit tests"
+run = "pnpm test"
+dir = "{{config_root}}/web"
+
+[tasks."test:e2e"]
+description = "Run E2E tests"
+depends = ["build"]
+run = "pnpm test:e2e"
+dir = "{{config_root}}/web"
+
 [tasks.format]
 description = "Format code with Prettier and fix lint"
 run = "pnpm format"
@@ -30,4 +41,4 @@ dir = "{{config_root}}/web"
 
 [tasks.verify]
 description = "Run all verification checks"
-depends = ["lint", "build"]
+depends = ["lint", "test", "test:e2e"]

--- a/mise.toml
+++ b/mise.toml
@@ -41,4 +41,5 @@ dir = "{{config_root}}/web"
 
 [tasks.verify]
 description = "Run all verification checks"
-depends = ["lint", "test", "test:e2e"]
+run = "pnpm lint && pnpm test && pnpm build && pnpm test:e2e"
+dir = "{{config_root}}/web"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
 
 # next.js
 /.next/

--- a/web/e2e/content.spec.ts
+++ b/web/e2e/content.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test("home page exposes the main notes entry points", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "Hello, I'm yona!" }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Notes" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+});
+
+test("notes page lists published notes and hides drafts", async ({ page }) => {
+  await page.goto("/notes");
+
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "ブロックスタイルテスト" }),
+  ).toHaveCount(0);
+});
+
+test("note detail renders metadata and representative blocks", async ({ page }) => {
+  await page.goto("/notes/site-renewal");
+
+  await expect(
+    page.getByRole("heading", { name: "yona.dev をリニューアルしました" }),
+  ).toBeVisible();
+  await expect(page.getByText("2026.04.26")).toBeVisible();
+  await expect(page.getByText("ノート")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "サイトについて" }),
+  ).toBeVisible();
+  await expect(page.getByText("この note の下書きは")).toBeVisible();
+});
+
+test("legacy blog routes redirect to notes", async ({ page }) => {
+  await page.goto("/blog");
+  await expect(page).toHaveURL(/\/notes$/);
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+
+  await page.goto("/blog/anything");
+  await expect(page).toHaveURL(/\/notes$/);
+  await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+});

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "if [ \"$ANALYZE\" = \"true\" ]; then next build --webpack; else next build; fi",
     "start": "next start",
     "lint": "eslint '**/*.@(js|ts|tsx)'",
+    "test": "vitest run",
     "format": "prettier --write . && pnpm lint --fix"
   },
   "dependencies": {
@@ -35,7 +36,8 @@
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^17.5.0",
     "prettier": "^3.8.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
   },
   "pnpm": {
     "overrides": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint '**/*.@(js|ts|tsx)'",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "format": "prettier --write . && pnpm lint --fix"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "@eslint/js": "^9.39.4",
     "@next/bundle-analyzer": "^16.2.4",
     "@next/eslint-plugin-next": "^16.2.4",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@typescript-eslint/eslint-plugin": "^8.59.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = Number(process.env.PLAYWRIGHT_PORT ?? 3100);
 const baseUrl = `http://127.0.0.1:${port}`;
+const reuseExistingServer = process.env.PLAYWRIGHT_REUSE_SERVER === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -18,7 +19,7 @@ export default defineConfig({
   webServer: {
     command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
     url: baseUrl,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer,
     timeout: 60_000,
   },
   projects: [

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 3100);
+const baseUrl = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  reporter: "list",
+  use: {
+    baseURL: baseUrl,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
+    url: baseUrl,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.11(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
@@ -372,6 +375,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/bundle-analyzer@16.2.4':
     resolution: {integrity: sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==}
 
@@ -445,17 +454,121 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -626,6 +739,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -685,6 +827,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -751,6 +897,10 @@ packages:
 
   caniuse-lite@1.0.30001790:
     resolution: {integrity: sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -865,6 +1015,9 @@ packages:
   es-iterator-helpers@1.3.2:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1017,9 +1170,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1068,6 +1228,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1359,6 +1524,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1372,6 +1607,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1475,6 +1713,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -1509,6 +1750,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1584,6 +1828,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1651,6 +1900,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -1661,6 +1913,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1718,9 +1976,20 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1793,6 +2062,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.0.11:
+    resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
     engines: {node: '>= 10.13.0'}
@@ -1817,6 +2170,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2156,6 +2514,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/bundle-analyzer@16.2.4':
     dependencies:
       webpack-bundle-analyzer: 4.10.1
@@ -2207,9 +2572,64 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@oxc-project/types@0.128.0': {}
+
   '@polka/url@1.0.0-next.29': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2219,6 +2639,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2384,6 +2811,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@25.6.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.11(@types/node@25.6.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2476,6 +2944,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2535,6 +3005,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001790: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2607,8 +3079,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -2705,6 +3176,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -2942,7 +3415,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2989,6 +3468,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3279,6 +3761,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -3292,6 +3823,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -3397,6 +3932,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   opener@1.5.2: {}
 
   optionator@0.9.4:
@@ -3431,6 +3968,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3503,6 +4042,27 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.18:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
 
   run-parallel@1.2.0:
     dependencies:
@@ -3621,6 +4181,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3630,6 +4192,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -3703,10 +4269,16 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3820,6 +4392,45 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.0.11(@types/node@25.6.0)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.18
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.11(@types/node@25.6.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@25.6.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.11(@types/node@25.6.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   webpack-bundle-analyzer@4.10.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -3883,6 +4494,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       next:
         specifier: ^16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -30,6 +30,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^16.2.4
         version: 16.2.4
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -456,6 +459,11 @@ packages:
 
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1229,6 +1237,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1764,6 +1777,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -2573,6 +2596,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.128.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -3469,6 +3496,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3857,7 +3887,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -3876,6 +3906,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3976,6 +4007,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/web/src/components/site/ArticleContent.test.tsx
+++ b/web/src/components/site/ArticleContent.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { ArticleBlock } from "../../lib/content";
+import { ArticleContent } from "./ArticleContent";
+
+describe("ArticleContent", () => {
+  it("renders representative article blocks", () => {
+    const blocks: ArticleBlock[] = [
+      { kind: "heading", level: 2, text: "Section" },
+      { kind: "paragraph", text: "Paragraph body" },
+      { kind: "list", items: ["First", "Second"] },
+      { kind: "quote", text: "Quote body" },
+      { kind: "code", code: "const value = 1;", language: "ts" },
+      {
+        kind: "image",
+        asset: { id: "image", src: "/image.png", alt: "Image alt" },
+        caption: "Image caption",
+      },
+      { kind: "callout", tone: "warning", text: "Warning body" },
+      {
+        kind: "linkCard",
+        title: "Example",
+        url: "https://example.com/path",
+        description: "Example description",
+      },
+      {
+        kind: "gallery",
+        images: [{ id: "gallery", src: "/gallery.png", alt: "Gallery alt" }],
+      },
+    ];
+
+    const markup = renderToStaticMarkup(<ArticleContent blocks={blocks} />);
+
+    expect(markup).toContain("<h2>Section</h2>");
+    expect(markup).toContain("<p>Paragraph body</p>");
+    expect(markup).toContain("<li>First</li>");
+    expect(markup).toContain("<blockquote>Quote body</blockquote>");
+    expect(markup).toContain("<code>const value = 1;</code>");
+    expect(markup).toContain('alt="Image alt"');
+    expect(markup).toContain("<figcaption>Image caption</figcaption>");
+    expect(markup).toContain("Warning body");
+    expect(markup).toContain('href="https://example.com/path"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('alt="Gallery alt"');
+  });
+
+  it("rejects unsafe linkCard protocols during render", () => {
+    const blocks: ArticleBlock[] = [
+      {
+        kind: "linkCard",
+        title: "Unsafe",
+        url: "javascript:alert(1)",
+      },
+    ];
+
+    expect(() =>
+      renderToStaticMarkup(<ArticleContent blocks={blocks} />),
+    ).toThrow("Unsupported linkCard URL protocol: javascript:");
+  });
+});

--- a/web/src/lib/content/blocks.test.ts
+++ b/web/src/lib/content/blocks.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { parseArticleBlocks } from "./blocks";
+
+describe("parseArticleBlocks", () => {
+  it("parses core Markdown blocks into ArticleBlock objects", () => {
+    const blocks = parseArticleBlocks(`# Title
+
+Intro line
+continued line
+
+## Section
+
+- First
+- Second
+
+> Quote line
+> continued quote
+
+\`\`\`ts
+const value = "ok";
+\`\`\`
+
+![Alt text](/image.png "Caption text")`);
+
+    expect(blocks).toEqual([
+      { kind: "heading", level: 1, text: "Title" },
+      { kind: "paragraph", text: "Intro line continued line" },
+      { kind: "heading", level: 2, text: "Section" },
+      { kind: "list", items: ["First", "Second"] },
+      { kind: "quote", text: "Quote line continued quote" },
+      { kind: "code", code: 'const value = "ok";', language: "ts" },
+      {
+        kind: "image",
+        asset: {
+          id: "/image.png",
+          src: "/image.png",
+          alt: "Alt text",
+        },
+        caption: "Caption text",
+      },
+    ]);
+  });
+
+  it("parses note and warning callouts", () => {
+    expect(
+      parseArticleBlocks(`:::callout
+Note body
+:::
+
+:::callout warning
+Warning body
+:::`),
+    ).toEqual([
+      { kind: "callout", tone: "note", text: "Note body" },
+      { kind: "callout", tone: "warning", text: "Warning body" },
+    ]);
+  });
+
+  it("rejects unclosed callout blocks", () => {
+    expect(() => parseArticleBlocks(":::callout\nMissing close")).toThrow(
+      "Unclosed callout block",
+    );
+  });
+
+  it("rejects unclosed code blocks", () => {
+    expect(() => parseArticleBlocks("```ts\nconst value = 1;")).toThrow(
+      "Unclosed code block",
+    );
+  });
+
+  it("rejects unsupported custom block syntax", () => {
+    expect(() => parseArticleBlocks("::link-card\nhttps://example.com")).toThrow(
+      "Unsupported custom block syntax: ::link-card",
+    );
+  });
+});

--- a/web/src/lib/content/markdown-source.test.ts
+++ b/web/src/lib/content/markdown-source.test.ts
@@ -9,13 +9,13 @@ import { createMarkdownSource } from "./markdown-source";
 const createdDirectories: string[] = [];
 
 const makeNotesDirectory = async (
-  files: Record<string, string>,
+  files: ReadonlyArray<readonly [fileName: string, content: string]>,
 ): Promise<string> => {
   const directory = await mkdtemp(path.join(tmpdir(), "yona-notes-"));
   createdDirectories.push(directory);
 
   await Promise.all(
-    Object.entries(files).map(([fileName, content]) =>
+    files.map(([fileName, content]) =>
       writeFile(path.join(directory, fileName), content),
     ),
   );
@@ -65,11 +65,11 @@ Draft body`;
 
 describe("createMarkdownSource", () => {
   it("returns only published articles sorted by publishedAt descending", async () => {
-    const directory = await makeNotesDirectory({
-      "new.md": publishedNew,
-      "old.md": publishedOld,
-      "draft.md": draft,
-    });
+    const directory = await makeNotesDirectory([
+      ["new.md", publishedNew],
+      ["old.md", publishedOld],
+      ["draft.md", draft],
+    ]);
     const source = createMarkdownSource(directory);
 
     const articles = await source.getAllArticles();
@@ -90,10 +90,10 @@ describe("createMarkdownSource", () => {
   });
 
   it("returns articles by slug and omits unpublished slugs", async () => {
-    const directory = await makeNotesDirectory({
-      "new.md": publishedNew,
-      "draft.md": draft,
-    });
+    const directory = await makeNotesDirectory([
+      ["new.md", publishedNew],
+      ["draft.md", draft],
+    ]);
     const source = createMarkdownSource(directory);
 
     await expect(source.getArticleSlugs()).resolves.toEqual(["new-note"]);
@@ -105,9 +105,7 @@ describe("createMarkdownSource", () => {
   });
 
   it("rejects Markdown without valid frontmatter", async () => {
-    const directory = await makeNotesDirectory({
-      "invalid.md": "No frontmatter",
-    });
+    const directory = await makeNotesDirectory([["invalid.md", "No frontmatter"]]);
     const source = createMarkdownSource(directory);
 
     await expect(source.getAllArticles()).rejects.toThrow(
@@ -116,8 +114,10 @@ describe("createMarkdownSource", () => {
   });
 
   it("rejects invalid frontmatter shape", async () => {
-    const directory = await makeNotesDirectory({
-      "invalid.md": `---
+    const directory = await makeNotesDirectory([
+      [
+        "invalid.md",
+        `---
 title: Invalid
 slug: invalid
 date: 2026-05-02
@@ -125,7 +125,8 @@ type: note
 description: Missing published
 ---
 Body`,
-    });
+      ],
+    ]);
     const source = createMarkdownSource(directory);
 
     await expect(source.getAllArticles()).rejects.toThrow(
@@ -134,8 +135,10 @@ Body`,
   });
 
   it("rejects unsupported article kinds", async () => {
-    const directory = await makeNotesDirectory({
-      "invalid-kind.md": `---
+    const directory = await makeNotesDirectory([
+      [
+        "invalid-kind.md",
+        `---
 title: Invalid Kind
 slug: invalid-kind
 date: 2026-05-02
@@ -144,7 +147,8 @@ description: Invalid kind
 published: true
 ---
 Body`,
-    });
+      ],
+    ]);
     const source = createMarkdownSource(directory);
 
     await expect(source.getAllArticles()).rejects.toThrow(
@@ -153,8 +157,10 @@ Body`,
   });
 
   it("rejects unsupported custom block syntax inside articles", async () => {
-    const directory = await makeNotesDirectory({
-      "custom.md": `---
+    const directory = await makeNotesDirectory([
+      [
+        "custom.md",
+        `---
 title: Custom Block
 slug: custom-block
 date: 2026-05-02
@@ -164,7 +170,8 @@ published: true
 ---
 ::unknown
 value`,
-    });
+      ],
+    ]);
     const source = createMarkdownSource(directory);
 
     await expect(source.getAllArticles()).rejects.toThrow(

--- a/web/src/lib/content/markdown-source.test.ts
+++ b/web/src/lib/content/markdown-source.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createMarkdownSource } from "./markdown-source";
+
+const createdDirectories: string[] = [];
+
+const makeNotesDirectory = async (
+  files: Record<string, string>,
+): Promise<string> => {
+  const directory = await mkdtemp(path.join(tmpdir(), "yona-notes-"));
+  createdDirectories.push(directory);
+
+  await Promise.all(
+    Object.entries(files).map(([fileName, content]) =>
+      writeFile(path.join(directory, fileName), content),
+    ),
+  );
+
+  return directory;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories.splice(0).map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  );
+});
+
+const publishedNew = `---
+title: New Note
+slug: new-note
+date: 2026-05-02
+type: note
+description: New description
+published: true
+---
+# New Note
+
+New body`;
+
+const publishedOld = `---
+title: Old Article
+slug: old-article
+date: 2026-05-01
+type: article
+description: Old description
+published: true
+---
+Old body`;
+
+const draft = `---
+title: Draft Log
+slug: draft-log
+date: 2026-05-03
+type: log
+description: Draft description
+published: false
+---
+Draft body`;
+
+describe("createMarkdownSource", () => {
+  it("returns only published articles sorted by publishedAt descending", async () => {
+    const directory = await makeNotesDirectory({
+      "new.md": publishedNew,
+      "old.md": publishedOld,
+      "draft.md": draft,
+    });
+    const source = createMarkdownSource(directory);
+
+    const articles = await source.getAllArticles();
+
+    expect(articles.map((article) => article.slug)).toEqual([
+      "new-note",
+      "old-article",
+    ]);
+    expect(articles[0]).toMatchObject({
+      id: "new-note",
+      title: "New Note",
+      description: "New description",
+      publishedAt: "2026-05-02",
+      kind: "note",
+      isPublished: true,
+      blocks: [{ kind: "paragraph", text: "New body" }],
+    });
+  });
+
+  it("returns articles by slug and omits unpublished slugs", async () => {
+    const directory = await makeNotesDirectory({
+      "new.md": publishedNew,
+      "draft.md": draft,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getArticleSlugs()).resolves.toEqual(["new-note"]);
+    await expect(source.getArticleBySlug("new-note")).resolves.toMatchObject({
+      slug: "new-note",
+    });
+    await expect(source.getArticleBySlug("draft-log")).resolves.toBeNull();
+    await expect(source.getArticleBySlug("missing")).resolves.toBeNull();
+  });
+
+  it("rejects Markdown without valid frontmatter", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid.md": "No frontmatter",
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Missing frontmatter in invalid.md",
+    );
+  });
+
+  it("rejects invalid frontmatter shape", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid.md": `---
+title: Invalid
+slug: invalid
+date: 2026-05-02
+type: note
+description: Missing published
+---
+Body`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Invalid frontmatter shape in invalid.md",
+    );
+  });
+
+  it("rejects unsupported article kinds", async () => {
+    const directory = await makeNotesDirectory({
+      "invalid-kind.md": `---
+title: Invalid Kind
+slug: invalid-kind
+date: 2026-05-02
+type: diary
+description: Invalid kind
+published: true
+---
+Body`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Invalid article kind in invalid-kind.md: diary",
+    );
+  });
+
+  it("rejects unsupported custom block syntax inside articles", async () => {
+    const directory = await makeNotesDirectory({
+      "custom.md": `---
+title: Custom Block
+slug: custom-block
+date: 2026-05-02
+type: note
+description: Custom block
+published: true
+---
+::unknown
+value`,
+    });
+    const source = createMarkdownSource(directory);
+
+    await expect(source.getAllArticles()).rejects.toThrow(
+      "Unsupported custom block syntax: ::unknown",
+    );
+  });
+});

--- a/web/src/lib/content/markdown-source.ts
+++ b/web/src/lib/content/markdown-source.ts
@@ -16,7 +16,7 @@ type ArticleFrontmatter = {
   updatedAt?: string;
 };
 
-const notesDirectory = path.join(process.cwd(), "content", "notes");
+const defaultNotesDirectory = path.join(process.cwd(), "content", "notes");
 const articleKinds = new Set<ArticleKind>(["article", "note", "log"]);
 
 const normalizeArticleContent = (content: string, title: string): string => {
@@ -91,42 +91,48 @@ const parseFrontmatter = (
   };
 };
 
-const getAllMarkdownArticles = cache(async (): Promise<Article[]> => {
-  const fileNames = await fs.readdir(notesDirectory);
-  const articles = await Promise.all(
-    fileNames
-      .filter((fileName) => fileName.endsWith(".md"))
-      .map(async (fileName) => {
-        const source = await fs.readFile(path.join(notesDirectory, fileName), "utf8");
-        const { data, content } = parseFrontmatter(source, fileName);
+export const createMarkdownSource = (
+  notesDirectory = defaultNotesDirectory,
+): ContentSource => {
+  const getAllMarkdownArticles = cache(async (): Promise<Article[]> => {
+    const fileNames = await fs.readdir(notesDirectory);
+    const articles = await Promise.all(
+      fileNames
+        .filter((fileName) => fileName.endsWith(".md"))
+        .map(async (fileName) => {
+          const source = await fs.readFile(path.join(notesDirectory, fileName), "utf8");
+          const { data, content } = parseFrontmatter(source, fileName);
 
-        return {
-          id: data.slug,
-          slug: data.slug,
-          title: data.title,
-          description: data.description,
-          publishedAt: data.date,
-          updatedAt: data.updatedAt,
-          kind: data.type,
-          isPublished: data.published,
-          blocks: parseArticleBlocks(content),
-        } satisfies Article;
-      }),
-  );
+          return {
+            id: data.slug,
+            slug: data.slug,
+            title: data.title,
+            description: data.description,
+            publishedAt: data.date,
+            updatedAt: data.updatedAt,
+            kind: data.type,
+            isPublished: data.published,
+            blocks: parseArticleBlocks(content),
+          } satisfies Article;
+        }),
+    );
 
-  return articles
-    .filter((article) => article.isPublished)
-    .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
-});
+    return articles
+      .filter((article) => article.isPublished)
+      .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+  });
 
-export const markdownSource: ContentSource = {
-  getAllArticles: getAllMarkdownArticles,
-  async getArticleBySlug(slug) {
-    const articles = await getAllMarkdownArticles();
-    return articles.find((article) => article.slug === slug) ?? null;
-  },
-  async getArticleSlugs() {
-    const articles = await getAllMarkdownArticles();
-    return articles.map((article) => article.slug);
-  },
+  return {
+    getAllArticles: getAllMarkdownArticles,
+    async getArticleBySlug(slug) {
+      const articles = await getAllMarkdownArticles();
+      return articles.find((article) => article.slug === slug) ?? null;
+    },
+    async getArticleSlugs() {
+      const articles = await getAllMarkdownArticles();
+      return articles.map((article) => article.slug);
+    },
+  };
 };
+
+export const markdownSource = createMarkdownSource();

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+    restoreMocks: true,
+    watch: false,
+  },
+});


### PR DESCRIPTION
## 概要

Vitest と Playwright を導入し、Markdown content、記事 renderer、公開 route の回帰テストを追加します。`mise run verify` は lint、unit test、build、E2E を直列実行する hard guard になります。

## 背景・動機

Notes 中心の構成に刷新された後、公開 content の parse、render、redirect が手動確認に寄っていたため、今後の変更で壊れやすい境界を自動検証できるようにします。

## やったこと

### テスト基盤

- 変更前: lint と build のみが verify 対象でした。
- 変更後: `pnpm test` と `pnpm test:e2e` を追加し、`mise run verify` で `pnpm lint && pnpm test && pnpm build && pnpm test:e2e` を順に実行します。

### content の回帰テスト

- 変更前: `ArticleBlock` parse、Markdown frontmatter、公開記事 filter、slug 取得の契約がテストされていませんでした。
- 変更後: Vitest で parser、`ContentSource` fixture、`ArticleContent` renderer の代表ケースを検証します。

### 公開 route の E2E

- 変更前: `/`、`/notes`、`/notes/[slug]`、旧 `/blog` route の表示・redirect を自動確認できませんでした。
- 変更後: Playwright で主要導線、draft 非表示、記事詳細、旧 blog redirect を検証します。

### ドキュメント

- `docs/conventions.md` と `README.md` の Testing / 検証説明を、実装後の verify 構成に合わせました。

## 確認方法

- `mise run verify`
  - `pnpm lint`
  - Vitest: 3 files / 13 tests
  - Next.js build
  - Playwright: 4 tests

## 影響範囲とリスク

- ユーザー向けの表示変更はありません。
- `createMarkdownSource(notesDirectory)` を追加していますが、既存の `markdownSource` は既定 directory のまま維持しています。
- Playwright は Chromium を起動するため、この環境では通常サンドボックスだと macOS MachPort 権限で失敗します。最終確認は権限付きで通過済みです。

## 関連Issue

なし
